### PR TITLE
Add header input type to support multi headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vacasaoss/ts-force-project",
-  "version": "3.4.5",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vacasaoss/ts-force-project",
-      "version": "3.4.5",
+      "version": "4.0.0",
       "hasInstallScript": true,
       "license": "ISC"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vacasaoss/ts-force-project",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vacasaoss/ts-force-project",
-      "version": "3.4.4",
+      "version": "3.4.5",
       "hasInstallScript": true,
       "license": "ISC"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vacasaoss/ts-force-project",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "description": "",
   "scripts": {
     "postinstall": "cd ts-force && npm install && npm run build && cd ../ts-force-gen && npm install",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vacasaoss/ts-force-project",
-  "version": "3.4.5",
+  "version": "4.0.0",
   "description": "",
   "scripts": {
     "postinstall": "cd ts-force && npm install && npm run build && cd ../ts-force-gen && npm install",

--- a/ts-force-gen/package-lock.json
+++ b/ts-force-gen/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vacasaoss/ts-force-gen",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vacasaoss/ts-force-gen",
-      "version": "3.4.4",
+      "version": "3.4.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/core": "^2.12.3",

--- a/ts-force-gen/package-lock.json
+++ b/ts-force-gen/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vacasaoss/ts-force-gen",
-  "version": "3.4.5",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vacasaoss/ts-force-gen",
-      "version": "3.4.5",
+      "version": "4.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/core": "^2.12.3",

--- a/ts-force-gen/package.json
+++ b/ts-force-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vacasaoss/ts-force-gen",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "description": "Code generation for ts-force",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/ts-force-gen/package.json
+++ b/ts-force-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vacasaoss/ts-force-gen",
-  "version": "3.4.5",
+  "version": "4.0.0",
   "description": "Code generation for ts-force",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/ts-force/package-lock.json
+++ b/ts-force/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vacasaoss/ts-force",
-  "version": "3.4.5",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vacasaoss/ts-force",
-      "version": "3.4.5",
+      "version": "4.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/cometd": "^4.0.4",

--- a/ts-force/package-lock.json
+++ b/ts-force/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vacasaoss/ts-force",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vacasaoss/ts-force",
-      "version": "3.4.4",
+      "version": "3.4.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/cometd": "^4.0.4",

--- a/ts-force/package.json
+++ b/ts-force/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vacasaoss/ts-force",
-  "version": "3.4.5",
+  "version": "4.0.0",
   "description": "a typescript client for connecting with salesforce APIs",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/ts-force/package.json
+++ b/ts-force/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vacasaoss/ts-force",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "description": "a typescript client for connecting with salesforce APIs",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/ts-force/src/rest/restHeader.ts
+++ b/ts-force/src/rest/restHeader.ts
@@ -6,6 +6,11 @@ export type PackageVersion = {
   version: string;
 };
 
+export type GenericHeader = {
+  header: string;
+  value: string;
+};
+
 export type RequestHeadersInput = {
   'Sforce-Auto-Assign'?: boolean;
   'Sforce-Mru'?: SforceMru;
@@ -14,7 +19,12 @@ export type RequestHeadersInput = {
   'If-Unmodified-Since'?: Date;
   'If-Match'?: string[];
   'If-None-Match'?: string[];
+  'Generic-Header'?: GenericHeader;
 };
 
-export const GetOrHeadRequestHeaders: (keyof RequestHeadersInput)[] = ['If-Match', 'If-None-Match', 'If-Modified-Since'];
-export const PatchOrPostRequestHeaders: (keyof RequestHeadersInput)[] = ['If-Match', 'If-None-Match', 'If-Unmodified-Since'];
+export const ConditionalRequestHeaders: (keyof RequestHeadersInput)[] = [
+  'If-Match',
+  'If-None-Match',
+  'If-Modified-Since',
+  'If-Unmodified-Since',
+];

--- a/ts-force/src/rest/restHeader.ts
+++ b/ts-force/src/rest/restHeader.ts
@@ -8,7 +8,6 @@ export type PackageVersion = {
 
 export type RequestHeadersInput = {
   'Sforce-Auto-Assign'?: boolean;
-  'Content-Encoding'?: 'gzip' | 'deflate';
   'Sforce-Mru'?: SforceMru;
   'x-sfdc-packageversion'?: PackageVersion;
   'If-Modified-Since'?: Date;

--- a/ts-force/src/rest/restHeader.ts
+++ b/ts-force/src/rest/restHeader.ts
@@ -1,30 +1,8 @@
-export type SforceMru = {
-  updateMru: boolean;
-};
-export type PackageVersion = {
-  package: string;
-  version: string;
-};
-
-export type GenericHeader = {
-  header: string;
-  value: string;
-};
-
 export type RequestHeadersInput = {
   'Sforce-Auto-Assign'?: boolean;
-  'Sforce-Mru'?: SforceMru;
-  'x-sfdc-packageversion'?: PackageVersion;
   'If-Modified-Since'?: Date;
   'If-Unmodified-Since'?: Date;
-  'If-Match'?: string[];
-  'If-None-Match'?: string[];
-  'Generic-Header'?: GenericHeader;
 };
+export type GeneralRequestHeadersInput = RequestHeadersInput | Record<string, string>;
 
-export const ConditionalRequestHeaders: (keyof RequestHeadersInput)[] = [
-  'If-Match',
-  'If-None-Match',
-  'If-Modified-Since',
-  'If-Unmodified-Since',
-];
+export const ConditionalRequestHeaders = ['If-Match', 'If-None-Match', 'If-Modified-Since', 'If-Unmodified-Since'];

--- a/ts-force/src/rest/restHeader.ts
+++ b/ts-force/src/rest/restHeader.ts
@@ -33,5 +33,5 @@ export type RequestHeadersInput = {
   'If-None-Match'?: string[];
 };
 
-export const GetOrHeadRequestHeaders = ['If-Match', 'If-None-Match', 'If-Modified-Since'];
-export const PatchOrPostRequestHeaders = ['If-Match', 'If-None-Match', 'If-Unmodified-Since'];
+export const GetOrHeadRequestHeaders: (keyof RequestHeadersInput)[] = ['If-Match', 'If-None-Match', 'If-Modified-Since'];
+export const PatchOrPostRequestHeaders: (keyof RequestHeadersInput)[] = ['If-Match', 'If-None-Match', 'If-Unmodified-Since'];

--- a/ts-force/src/rest/restHeader.ts
+++ b/ts-force/src/rest/restHeader.ts
@@ -1,17 +1,5 @@
-export type SforceCallOptions = {
-  client?: string;
-  defaultNamespace?: string;
-};
-export type SforceDuplicateRule = {
-  allowSave?: boolean;
-  includeRecordDetails?: boolean;
-  runAsCurrentUser?: boolean;
-};
 export type SforceMru = {
   updateMru: boolean;
-};
-export type SforceQueryOptions = {
-  batchSize: number;
 };
 export type PackageVersion = {
   package: string;
@@ -20,12 +8,8 @@ export type PackageVersion = {
 
 export type RequestHeadersInput = {
   'Sforce-Auto-Assign'?: boolean;
-  'Sforce-Call-Options'?: SforceCallOptions;
   'Content-Encoding'?: 'gzip' | 'deflate';
-  ETag?: string;
-  'Sforce-Duplicate-Rule-Header'?: SforceDuplicateRule;
   'Sforce-Mru'?: SforceMru;
-  'Sforce-Query-Options'?: SforceQueryOptions;
   'x-sfdc-packageversion'?: PackageVersion;
   'If-Modified-Since'?: Date;
   'If-Unmodified-Since'?: Date;

--- a/ts-force/src/rest/restHeader.ts
+++ b/ts-force/src/rest/restHeader.ts
@@ -1,0 +1,37 @@
+export type SforceCallOptions = {
+  client?: string;
+  defaultNamespace?: string;
+};
+export type SforceDuplicateRule = {
+  allowSave?: boolean;
+  includeRecordDetails?: boolean;
+  runAsCurrentUser?: boolean;
+};
+export type SforceMru = {
+  updateMru: boolean;
+};
+export type SforceQueryOptions = {
+  batchSize: number;
+};
+export type PackageVersion = {
+  package: string;
+  version: string;
+};
+
+export type RequestHeadersInput = {
+  'Sforce-Auto-Assign'?: boolean;
+  'Sforce-Call-Options'?: SforceCallOptions;
+  'Content-Encoding'?: 'gzip' | 'deflate';
+  ETag?: string;
+  'Sforce-Duplicate-Rule-Header'?: SforceDuplicateRule;
+  'Sforce-Mru'?: SforceMru;
+  'Sforce-Query-Options'?: SforceQueryOptions;
+  'x-sfdc-packageversion'?: PackageVersion;
+  'If-Modified-Since'?: Date;
+  'If-Unmodified-Since'?: Date;
+  'If-Match'?: string[];
+  'If-None-Match'?: string[];
+};
+
+export const GetOrHeadRequestHeaders = ['If-Match', 'If-None-Match', 'If-Modified-Since'];
+export const PatchOrPostRequestHeaders = ['If-Match', 'If-None-Match', 'If-Unmodified-Since'];

--- a/ts-force/src/rest/restObject.ts
+++ b/ts-force/src/rest/restObject.ts
@@ -513,14 +513,12 @@ export abstract class RestObject extends SObject {
   private setHeader(headersInput: RequestHeadersInput[]) {
     const headers = {};
     for (const header of headersInput) {
-      for (const [name, value] of Object.entries(headersInput)) {
+      for (const [name, value] of Object.entries(header)) {
         switch (name) {
-          case 'Sforce-Auto-Assign':
-            headers[name] = value as unknown as boolean;
-            break;
           case 'Sforce-Call-Options':
             headers[name] = this.parseSforceCallOptions(value as SforceCallOptions);
             break;
+          case 'Sforce-Auto-Assign':
           case 'Content-Encoding':
           case 'ETag':
             headers[name] = value;

--- a/ts-force/src/rest/restObject.ts
+++ b/ts-force/src/rest/restObject.ts
@@ -526,6 +526,7 @@ export abstract class RestObject extends SObject {
           default:
             const defaultValue = value as GenericHeader;
             headers[defaultValue.header] = defaultValue.value;
+            break;
         }
       }
     }

--- a/ts-force/src/rest/restObject.ts
+++ b/ts-force/src/rest/restObject.ts
@@ -511,7 +511,6 @@ export abstract class RestObject extends SObject {
       for (const [name, value] of Object.entries(header)) {
         switch (name) {
           case 'Sforce-Auto-Assign':
-          case 'Content-Encoding':
             headers[name] = value.toString();
             break;
           case 'If-Match':

--- a/ts-force/src/rest/restObject.ts
+++ b/ts-force/src/rest/restObject.ts
@@ -555,7 +555,7 @@ export abstract class RestObject extends SObject {
           break;
         case 'If-Match':
         case 'If-None-Match':
-          headers[name] = (value as string[]).join(', ');
+          headers[name] = `"${(value as string[]).join('", "')}"`;
           break;
         case 'If-Modified-Since':
         case 'If-Unmodified-Since':

--- a/ts-force/src/rest/restObject.ts
+++ b/ts-force/src/rest/restObject.ts
@@ -556,7 +556,7 @@ export abstract class RestObject extends SObject {
           headers[name] = this.parseSforceCallOptionsHeader(value as SforceCallOptionsHeader);
           break;
         case 'Content-Encoding':
-          headers[name] = value as 'gzip' | 'deflate';
+          headers[name] = value;
           break;
         case 'ETag':
           headers[name] = value as string;
@@ -576,7 +576,7 @@ export abstract class RestObject extends SObject {
           headers[name] = value as unknown as boolean;
           break;
         case 'Sforce-Query-Options':
-          headers[name] = `batchSize=${value}`;
+          headers[name] = `batchSize=${(value as SforceQueryOptionsHeader).batchSize}`;
           break;
         case 'x-sfdc-packageversion':
           const packageDetail = value as PackageVersionHeader;

--- a/ts-force/src/rest/restObject.ts
+++ b/ts-force/src/rest/restObject.ts
@@ -254,8 +254,12 @@ export abstract class RestObject extends SObject {
       );
 
       // Check if it contains Conditional Request Headers and deal with errors
-      const containsGetOrHeadHeader = Object.keys(opts.headers).some((key) => GetOrHeadRequestHeaders.includes(key));
-      const containsPatchOrPostHeader = Object.keys(opts.headers).some((key) => PatchOrPostRequestHeaders.includes(key));
+      const containsGetOrHeadHeader = Object.keys(opts.headers).some((key) =>
+        GetOrHeadRequestHeaders.includes(key as keyof RequestHeadersInput)
+      );
+      const containsPatchOrPostHeader = Object.keys(opts.headers).some((key) =>
+        PatchOrPostRequestHeaders.includes(key as keyof RequestHeadersInput)
+      );
       if (containsGetOrHeadHeader && response.status === 304) {
         throw new Error('Not Modified');
       } else if (containsPatchOrPostHeader && response.status === 412) {

--- a/ts-force/src/test/rest/restObjects.spec.ts
+++ b/ts-force/src/test/rest/restObjects.spec.ts
@@ -173,14 +173,17 @@ describe('Generated Classes', () => {
   });
 
   it('handle multiple headers', async () => {
-    const modifiedDate = new Date();
     let acc = new Account({
       name: 'account',
     });
     await acc.insert();
     //@ts-expect-error
     acc._client.request.interceptors.request.use((config) => {
-      if (config.method === 'patch') expect(config.headers['If-Modified-Since']).to.equal(modifiedDate.toUTCString());
+      if (config.method === 'patch') expect(config.headers['Sforce-Auto-Assign']).to.equal('false');
+      if (config.method === 'patch') expect(config.headers['Sforce-Mru']).to.equal('updateMru=true');
+      if (config.method === 'patch') expect(config.headers['If-Unmodified-Since']).to.equal(new Date().toUTCString());
+      if (config.method === 'patch') expect(config.headers['If-Modified-Since']).to.equal(new Date('2021-12-12').toUTCString());
+      if (config.method === 'patch') expect(config.headers['Custom-Header']).to.equal('Custom-Value');
       return config;
     });
     acc.name = 'account2';
@@ -192,29 +195,7 @@ describe('Generated Classes', () => {
           'If-Modified-Since': new Date('2021-12-12'),
           'Sforce-Auto-Assign': false,
           'Sforce-Mru': { updateMru: true },
-        },
-      ],
-    });
-    await acc.delete();
-  });
-
-  it('handle generic headers', async () => {
-    const modifiedDate = new Date();
-    let acc = new Account({
-      name: 'account',
-    });
-    await acc.insert();
-    //@ts-expect-error
-    acc._client.request.interceptors.request.use((config) => {
-      if (config.method === 'patch') expect(config.headers['If-Unmodified-Since']).to.equal(modifiedDate.toUTCString());
-      return config;
-    });
-    acc.name = 'account2';
-    await acc.update({
-      refresh: false,
-      headers: [
-        {
-          'Generic-Header': { header: 'Sforce-Mru', value: 'updateMru=true' },
+          'Generic-Header': { header: 'Custom-Header', value: 'Custom-Value' },
         },
       ],
     });

--- a/ts-force/src/test/rest/restObjects.spec.ts
+++ b/ts-force/src/test/rest/restObjects.spec.ts
@@ -179,25 +179,19 @@ describe('Generated Classes', () => {
     await acc.insert();
     //@ts-expect-error
     acc._client.request.interceptors.request.use((config) => {
-      if (config.method === 'patch') expect(config.headers['Sforce-Auto-Assign']).to.equal('false');
+      if (config.method === 'patch') expect(config.headers['Sforce-Auto-Assign']).to.equal('true');
       if (config.method === 'patch') expect(config.headers['Sforce-Mru']).to.equal('updateMru=true');
-      if (config.method === 'patch') expect(config.headers['If-Unmodified-Since']).to.equal(new Date().toUTCString());
-      if (config.method === 'patch') expect(config.headers['If-Modified-Since']).to.equal(new Date('2021-12-12').toUTCString());
-      if (config.method === 'patch') expect(config.headers['Custom-Header']).to.equal('Custom-Value');
+      if (config.method === 'patch') expect(config.headers['If-Modified-Since']).to.equal(new Date().toUTCString());
       return config;
     });
     acc.name = 'account2';
     await acc.update({
       refresh: false,
-      headers: [
-        {
-          'If-Unmodified-Since': new Date(),
-          'If-Modified-Since': new Date('2021-12-12'),
-          'Sforce-Auto-Assign': false,
-          'Sforce-Mru': { updateMru: true },
-          'Generic-Header': { header: 'Custom-Header', value: 'Custom-Value' },
-        },
-      ],
+      headers: {
+        'Sforce-Auto-Assign': true,
+        'If-Modified-Since': new Date(),
+        'Sforce-Mru': 'updateMru=true',
+      },
     });
     await acc.delete();
   });

--- a/ts-force/src/test/rest/restObjects.spec.ts
+++ b/ts-force/src/test/rest/restObjects.spec.ts
@@ -6,6 +6,8 @@ import { getCalendarDate } from '../../utils/calendarDate';
 import { Account, Contact, User } from '../assets/sobs';
 import { createDefaultClient } from '../helper';
 
+
+
 describe('Generated Classes', () => {
   before(async () => {
     await createDefaultClient();
@@ -14,7 +16,7 @@ describe('Generated Classes', () => {
   it('Parent Relationship', async () => {
     let acc = new Account({
       name: 'test account',
-      website: 'example.com',
+      website: 'example.com'
     });
 
     await acc.insert();
@@ -23,25 +25,22 @@ describe('Generated Classes', () => {
     let contact = new Contact({
       accountId: acc.id,
       firstName: `test`,
-      lastName: `contact`,
+      lastName: `contact`
     });
     await contact.insert();
 
-    let contact2 = (
-      await Contact.retrieve(
-        `SELECT ${Contact.FIELDS.name}, ${Contact.FIELDS.account}.${Account.FIELDS.website} FROM ${Contact.API_NAME} WHERE Id = '${contact.id}'`
-      )
-    )[0];
+    let contact2 = (await Contact.retrieve(`SELECT ${Contact.FIELDS.name}, ${Contact.FIELDS.account}.${Account.FIELDS.website} FROM ${Contact.API_NAME} WHERE Id = '${contact.id}'`))[0];
 
     expect(contact2.account).not.to.be.empty;
     expect(contact2.account.website).to.equal(acc.website);
 
-    let acc2 = (
-      await Account.retrieve((f) => ({
-        select: [...f.select('name', 'accountNumber'), ...f.parent('parent').select('id', 'accountNumber')],
-        where: [{ field: 'id', val: acc.id }],
-      }))
-    )[0];
+    let acc2 = (await Account.retrieve(f => ({
+      select: [
+        ...f.select('name', 'accountNumber'),
+        ...f.parent('parent').select('id', 'accountNumber')
+      ],
+      where: [{ field: 'id', val: acc.id }]
+    })))[0];
     // if the lookup rel is blank, it should be null
     expect(acc2.parent).to.be.null;
     expect(acc2.name).to.not.be.null;
@@ -57,18 +56,19 @@ describe('Generated Classes', () => {
   it('Child Relationship', async () => {
     let acc = new Account({
       name: 'test account',
-      website: 'example.com',
+      website: 'example.com'
     });
 
     await acc.insert();
     expect(acc.id).to.not.be.null;
 
-    let acc2 = (
-      await Account.retrieve((f) => ({
-        select: [...f.select('name', 'accountNumber'), f.subQuery('contacts', (cf) => ({ select: cf.select('id', 'firstName') }))],
-        where: [{ field: 'id', val: acc.id }],
-      }))
-    )[0];
+    let acc2 = (await Account.retrieve(f => ({
+      select: [
+        ...f.select('name', 'accountNumber'),
+        f.subQuery('contacts', cf => ({ select: cf.select('id', 'firstName') }))
+      ],
+      where: [{ field: 'id', val: acc.id }]
+    })))[0];
 
     expect(acc2.contacts).to.not.be.null;
     expect(acc2.contacts.length).to.eq(0);
@@ -76,16 +76,17 @@ describe('Generated Classes', () => {
     let contact = new Contact({
       accountId: acc.id,
       firstName: `test`,
-      lastName: `contact`,
+      lastName: `contact`
     });
     await contact.insert();
 
-    acc2 = (
-      await Account.retrieve((f) => ({
-        select: [...f.select('name', 'accountNumber'), f.subQuery('contacts', (cf) => ({ select: cf.select('id', 'firstName') }))],
-        where: [{ field: 'id', val: acc.id }],
-      }))
-    )[0];
+    acc2 = (await Account.retrieve(f => ({
+      select: [
+        ...f.select('name', 'accountNumber'),
+        f.subQuery('contacts', cf => ({ select: cf.select('id', 'firstName') }))
+      ],
+      where: [{ field: 'id', val: acc.id }]
+    })))[0];
     // if the lookup rel is blank, it should be null
     expect(acc2.contacts.length).to.eq(1);
     expect(acc2.contacts[0].firstName).to.eq(contact.firstName);
@@ -94,7 +95,7 @@ describe('Generated Classes', () => {
 
   it('DML End-to-End', async () => {
     let acc = new Account({
-      name: 'test account',
+      name: 'test account'
     });
     await acc.insert();
     expect(acc.id).to.not.be.null;
@@ -113,8 +114,9 @@ describe('Generated Classes', () => {
   });
 
   it('Stale Memory', async () => {
+
     let acc = new Account({
-      name: 'stale name',
+      name: 'stale name'
     });
     await acc.insert();
     expect(acc.id).to.not.be.null;
@@ -139,7 +141,7 @@ describe('Generated Classes', () => {
     // test update
     let acc4 = new Account({
       name: 'new name 2',
-      id: acc.id,
+      id: acc.id
     });
 
     await acc4.update();
@@ -157,8 +159,9 @@ describe('Generated Classes', () => {
   });
 
   it('prepareFor Update all', async () => {
+
     let acc = new Account({
-      name: 'account',
+      name: 'account'
     });
     await acc.insert();
 
@@ -170,11 +173,12 @@ describe('Generated Classes', () => {
     expect(sob['Name']).to.equal(acc2.name);
 
     await acc.delete();
-  });
-
+  })  
+  
   it('handle multiple headers', async () => {
+    const modifiedDate = new Date();
     let acc = new Account({
-      name: 'account',
+      name: 'account'
     });
     await acc.insert();
     //@ts-expect-error
@@ -182,9 +186,9 @@ describe('Generated Classes', () => {
       if (config.method === 'patch') expect(config.headers['Sforce-Auto-Assign']).to.equal('true');
       if (config.method === 'patch') expect(config.headers['Sforce-Mru']).to.equal('updateMru=true');
       if (config.method === 'patch') expect(config.headers['If-Modified-Since']).to.equal(new Date().toUTCString());
-      return config;
+      return config
     });
-    acc.name = 'account2';
+    acc.name = "account2";
     await acc.update({
       refresh: false,
       headers: {
@@ -194,14 +198,15 @@ describe('Generated Classes', () => {
       },
     });
     await acc.delete();
-  });
+  })
 
   it('multi-picklists', async () => {
+
     const { multiPick } = Account.PICKLIST;
 
     let acc = new Account({
       name: 'account',
-      multiPick: [multiPick.ONE, 'two'],
+      multiPick: [multiPick.ONE, 'two']
     });
     await acc.insert();
 
@@ -219,9 +224,10 @@ describe('Generated Classes', () => {
   });
 
   it('refresh', async () => {
+
     let acc = new Account({
       name: 'test account',
-      website: 'www.facepamplet.com',
+      website: 'www.facepamplet.com'
     });
     await acc.insert();
     let acc2 = (await Account.retrieve(`SELECT Id, Name FROM Account WHERE Id = '${acc.id}'`))[0];
@@ -238,14 +244,14 @@ describe('Generated Classes', () => {
     let acc = new Account({ name: 'testing' });
     await acc.insert();
 
-    let acc2 = (
-      await Account.retrieve((fields) => {
-        return {
-          select: fields.select('lastModifiedDate', 'createdById'),
-          where: [{ field: fields.select('id'), op: '=', val: acc.id }],
-        };
-      })
-    )[0];
+    let acc2 = (await Account.retrieve(fields => {
+      return {
+        select: fields.select('lastModifiedDate', 'createdById'),
+        where: [
+          { field: fields.select('id'), op: '=', val: acc.id }
+        ]
+      };
+    }))[0];
 
     expect(acc2.lastModifiedDate).not.null;
     expect(acc2.createdById).not.null;
@@ -253,73 +259,59 @@ describe('Generated Classes', () => {
 
   it('Collections End-to-End', async () => {
     let acc = new Account({
-      name: 'test account',
+      name: 'test account'
     });
     await acc.insert();
 
     let contacts = [];
     const contactSize = 50;
     for (let i = 0; i < contactSize; i++) {
-      contacts.push(
-        new Contact({
-          accountId: acc.id,
-          firstName: `test`,
-          lastName: `contact ${i}`,
-        })
-      );
+      contacts.push(new Contact({
+        accountId: acc.id,
+        firstName: `test`,
+        lastName: `contact ${i}`
+      }));
     }
 
     let bulk = new CompositeCollection();
     let insertResults = await bulk.insert(contacts);
     expect(contacts[0]._modified.size).to.equal(0);
 
-    insertResults.forEach((r) => {
+    insertResults.forEach(r => {
       if (!r.success) {
-        throw r.errors.map((e) => e.message).join(', ');
+        throw r.errors.map(e => e.message).join(', ');
       }
     });
 
-    acc = (
-      await Account.retrieve(
-        `SELECT Id, (SELECT ${Contact.FIELDS.name.apiName} FROM ${Account.FIELDS.contacts.apiName}) FROM Account WHERE Id = '${acc.id}'`
-      )
-    )[0];
+    acc = (await Account.retrieve(`SELECT Id, (SELECT ${Contact.FIELDS.name.apiName} FROM ${Account.FIELDS.contacts.apiName}) FROM Account WHERE Id = '${acc.id}'`))[0];
 
     expect(acc.contacts.length).to.equal(contactSize);
 
-    contacts.forEach((c) => {
+    contacts.forEach(c => {
       c.email = 'test@example.com';
     });
 
     let updateResults = await bulk.update(contacts);
     expect(contacts[0]._modified.size).to.equal(0);
-    updateResults.forEach((r) => {
+    updateResults.forEach(r => {
       if (!r.success) {
-        throw r.errors.map((e) => e.message).join(', ');
+        throw r.errors.map(e => e.message).join(', ');
       }
     });
 
-    acc = (
-      await Account.retrieve(
-        `SELECT Id, (SELECT ${Contact.FIELDS.name.apiName}, ${Contact.FIELDS.email} FROM ${Account.FIELDS.contacts.apiName}) FROM Account WHERE Id = '${acc.id}'`
-      )
-    )[0];
-    acc.contacts.forEach((c) => {
+    acc = (await Account.retrieve(`SELECT Id, (SELECT ${Contact.FIELDS.name.apiName}, ${Contact.FIELDS.email} FROM ${Account.FIELDS.contacts.apiName}) FROM Account WHERE Id = '${acc.id}'`))[0];
+    acc.contacts.forEach(c => {
       expect(c.email).to.equal('test@example.com');
     });
 
     let delResults = await bulk.delete(contacts);
-    delResults.forEach((r) => {
+    delResults.forEach(r => {
       if (!r.success) {
-        throw r.errors.map((e) => e.message).join(', ');
+        throw r.errors.map(e => e.message).join(', ');
       }
     });
 
-    acc = (
-      await Account.retrieve(
-        `SELECT Id, (SELECT ${Contact.FIELDS.name.apiName} FROM ${Account.FIELDS.contacts.apiName}) FROM Account WHERE Id = '${acc.id}'`
-      )
-    )[0];
+    acc = (await Account.retrieve(`SELECT Id, (SELECT ${Contact.FIELDS.name.apiName} FROM ${Account.FIELDS.contacts.apiName}) FROM Account WHERE Id = '${acc.id}'`))[0];
 
     expect(acc.contacts.length).to.equal(0);
 
@@ -329,10 +321,14 @@ describe('Generated Classes', () => {
   it('should set relation by external id', async () => {
     const extId = '123abcd';
     // setup account
-    let accs = await Account.retrieve((f) => {
+    let accs = await Account.retrieve(f => {
       return {
-        select: [...f.select('id', 'testExternalId')],
-        where: [{ field: f.select('testExternalId'), op: '=', val: extId }],
+        select: [
+          ...f.select('id', 'testExternalId')
+        ],
+        where: [
+          { field: f.select('testExternalId'), op: '=', val: extId }
+        ]
       };
     });
 
@@ -342,7 +338,7 @@ describe('Generated Classes', () => {
     } else {
       acc = new Account({
         name: 'test external id account',
-        testExternalId: extId,
+        testExternalId: extId
       });
       await acc.insert();
     }
@@ -350,74 +346,83 @@ describe('Generated Classes', () => {
     let contact = new Contact({
       firstName: 'john',
       lastName: 'doe',
-      account: new Account({ testExternalId: extId }),
+      account: new Account({ testExternalId: extId })
     });
 
     await contact.insert();
 
-    let retCont = await Contact.retrieve((f) => {
+    let retCont = await Contact.retrieve(f => {
       return {
-        select: [f.select('accountId')],
-        where: [{ field: f.select('id'), op: '=', val: contact.id }],
+        select: [
+          f.select('accountId')
+        ],
+        where: [
+          { field: f.select('id'), op: '=', val: contact.id }
+        ]
       };
     });
 
     expect(retCont[0].accountId).to.equal(acc.id);
+
   });
 
   it('prepareFor Apex', async () => {
+
     let c = new Contact({
       id: '123',
       accountId: 'abc',
       firstName: `john`,
       lastName: `doe`,
       account: new Account({
-        name: 'acme',
-      }),
+        name: 'acme'
+      })
     });
 
-    expect(c.toJson({ dmlMode: 'all', sendChildObj: true, sendParentObj: true, hideAttributes: true })).to.deep.equal({
-      Id: '123',
-      AccountId: 'abc',
-      FirstName: 'john',
-      LastName: 'doe',
-      Account: {
-        Name: 'acme',
-      },
-    });
+    expect(c.toJson({ dmlMode: 'all', sendChildObj: true, sendParentObj: true, hideAttributes: true })).to.deep.equal(
+      {
+        Id: '123',
+        AccountId: 'abc',
+        FirstName: 'john',
+        LastName: 'doe',
+        Account: {
+          Name: 'acme'
+        }
+      }
+    );
 
     let acc = new Account({
       id: '123',
-      contacts: [
-        new Contact({
-          firstName: 'john',
-          lastName: 'doe',
-        }),
-      ],
+      contacts: [new Contact({
+        firstName: 'john',
+        lastName: 'doe'
+      })]
     });
 
-    expect(acc.toJson({ dmlMode: 'all', sendChildObj: true, sendParentObj: true, hideAttributes: true })).to.deep.equal({
-      Id: '123',
-      Contacts: { records: [{ FirstName: 'john', LastName: 'doe' }] },
-    });
+    expect(acc.toJson({ dmlMode: 'all', sendChildObj: true, sendParentObj: true, hideAttributes: true })).to.deep.equal(
+      {
+        Id: '123',
+        Contacts: { records: [{ FirstName: 'john', LastName: 'doe' }] }
+      }
+    );
   });
 
   it('prepareFor Apex End To End', async () => {
     let acc = new Account({
       id: '123',
-      contacts: [
-        new Contact({
-          firstName: 'john',
-          lastName: 'doe',
-        }),
-      ],
+      contacts: [new Contact({
+        firstName: 'john',
+        lastName: 'doe'
+      })],
       owner: new User({
-        email: 'example@gmai.com',
-      }),
+        'email': 'example@gmai.com'
+      })
     });
 
     const sfSob = acc.toJson({ dmlMode: 'all', sendChildObj: true, sendParentObj: true, hideAttributes: true });
-    let data = (await new Rest().request.post<SObject>('/services/apexrest/myservice', { acc: sfSob })).data;
+    let data = (await new Rest().request.post<SObject>(
+      '/services/apexrest/myservice',
+      { acc: sfSob }
+    )).data;
     const retAcc = Account.fromSFObject(data);
     expect(acc.id).to.deep.equal(retAcc.id);
     expect(acc.contacts[0].firstName).to.deep.equal(retAcc.contacts[0].firstName);
@@ -427,8 +432,8 @@ describe('Generated Classes', () => {
 
   it('composite retrieve', async () => {
     let results = await compositeRetrieve(Contact, Account, User)(
-      (f) => ({ select: f.select('cleanStatus', 'email', 'accountId') }),
-      (f) => ({ select: f.select('numberOfEmployees', 'accountNumber', 'active') }),
+      f => ({ select: f.select('cleanStatus', 'email', 'accountId') }),
+      f => ({ select: f.select('numberOfEmployees', 'accountNumber', 'active') }),
       'select x from blah'
     );
     let contactResults = results[0];
@@ -460,20 +465,19 @@ describe('Generated Classes', () => {
     let c = new Contact({
       firstName: 'test',
       lastName: 'contact',
-      birthdate: getCalendarDate(),
+      birthdate: getCalendarDate()
     });
     await c.insert();
     expect(c.id).to.not.be.null;
 
-    let c2 = (
-      await Contact.retrieve((f) => ({
-        select: [f.select('birthdate')],
-        where: [{ field: 'id', val: c.id }],
-      }))
-    )[0];
+    let c2 = (await Contact.retrieve(f => ({
+      select: [f.select('birthdate')],
+      where: [{ field: 'id', val: c.id }]
+    })))[0];
 
     expect(c2.birthdate).to.deep.equal(c.birthdate);
 
     await c.delete();
   });
+
 });

--- a/ts-force/src/test/rest/restObjects.spec.ts
+++ b/ts-force/src/test/rest/restObjects.spec.ts
@@ -6,8 +6,6 @@ import { getCalendarDate } from '../../utils/calendarDate';
 import { Account, Contact, User } from '../assets/sobs';
 import { createDefaultClient } from '../helper';
 
-
-
 describe('Generated Classes', () => {
   before(async () => {
     await createDefaultClient();
@@ -16,7 +14,7 @@ describe('Generated Classes', () => {
   it('Parent Relationship', async () => {
     let acc = new Account({
       name: 'test account',
-      website: 'example.com'
+      website: 'example.com',
     });
 
     await acc.insert();
@@ -25,22 +23,25 @@ describe('Generated Classes', () => {
     let contact = new Contact({
       accountId: acc.id,
       firstName: `test`,
-      lastName: `contact`
+      lastName: `contact`,
     });
     await contact.insert();
 
-    let contact2 = (await Contact.retrieve(`SELECT ${Contact.FIELDS.name}, ${Contact.FIELDS.account}.${Account.FIELDS.website} FROM ${Contact.API_NAME} WHERE Id = '${contact.id}'`))[0];
+    let contact2 = (
+      await Contact.retrieve(
+        `SELECT ${Contact.FIELDS.name}, ${Contact.FIELDS.account}.${Account.FIELDS.website} FROM ${Contact.API_NAME} WHERE Id = '${contact.id}'`
+      )
+    )[0];
 
     expect(contact2.account).not.to.be.empty;
     expect(contact2.account.website).to.equal(acc.website);
 
-    let acc2 = (await Account.retrieve(f => ({
-      select: [
-        ...f.select('name', 'accountNumber'),
-        ...f.parent('parent').select('id', 'accountNumber')
-      ],
-      where: [{ field: 'id', val: acc.id }]
-    })))[0];
+    let acc2 = (
+      await Account.retrieve((f) => ({
+        select: [...f.select('name', 'accountNumber'), ...f.parent('parent').select('id', 'accountNumber')],
+        where: [{ field: 'id', val: acc.id }],
+      }))
+    )[0];
     // if the lookup rel is blank, it should be null
     expect(acc2.parent).to.be.null;
     expect(acc2.name).to.not.be.null;
@@ -56,19 +57,18 @@ describe('Generated Classes', () => {
   it('Child Relationship', async () => {
     let acc = new Account({
       name: 'test account',
-      website: 'example.com'
+      website: 'example.com',
     });
 
     await acc.insert();
     expect(acc.id).to.not.be.null;
 
-    let acc2 = (await Account.retrieve(f => ({
-      select: [
-        ...f.select('name', 'accountNumber'),
-        f.subQuery('contacts', cf => ({ select: cf.select('id', 'firstName') }))
-      ],
-      where: [{ field: 'id', val: acc.id }]
-    })))[0];
+    let acc2 = (
+      await Account.retrieve((f) => ({
+        select: [...f.select('name', 'accountNumber'), f.subQuery('contacts', (cf) => ({ select: cf.select('id', 'firstName') }))],
+        where: [{ field: 'id', val: acc.id }],
+      }))
+    )[0];
 
     expect(acc2.contacts).to.not.be.null;
     expect(acc2.contacts.length).to.eq(0);
@@ -76,17 +76,16 @@ describe('Generated Classes', () => {
     let contact = new Contact({
       accountId: acc.id,
       firstName: `test`,
-      lastName: `contact`
+      lastName: `contact`,
     });
     await contact.insert();
 
-    acc2 = (await Account.retrieve(f => ({
-      select: [
-        ...f.select('name', 'accountNumber'),
-        f.subQuery('contacts', cf => ({ select: cf.select('id', 'firstName') }))
-      ],
-      where: [{ field: 'id', val: acc.id }]
-    })))[0];
+    acc2 = (
+      await Account.retrieve((f) => ({
+        select: [...f.select('name', 'accountNumber'), f.subQuery('contacts', (cf) => ({ select: cf.select('id', 'firstName') }))],
+        where: [{ field: 'id', val: acc.id }],
+      }))
+    )[0];
     // if the lookup rel is blank, it should be null
     expect(acc2.contacts.length).to.eq(1);
     expect(acc2.contacts[0].firstName).to.eq(contact.firstName);
@@ -95,7 +94,7 @@ describe('Generated Classes', () => {
 
   it('DML End-to-End', async () => {
     let acc = new Account({
-      name: 'test account'
+      name: 'test account',
     });
     await acc.insert();
     expect(acc.id).to.not.be.null;
@@ -114,9 +113,8 @@ describe('Generated Classes', () => {
   });
 
   it('Stale Memory', async () => {
-
     let acc = new Account({
-      name: 'stale name'
+      name: 'stale name',
     });
     await acc.insert();
     expect(acc.id).to.not.be.null;
@@ -141,7 +139,7 @@ describe('Generated Classes', () => {
     // test update
     let acc4 = new Account({
       name: 'new name 2',
-      id: acc.id
+      id: acc.id,
     });
 
     await acc4.update();
@@ -159,9 +157,8 @@ describe('Generated Classes', () => {
   });
 
   it('prepareFor Update all', async () => {
-
     let acc = new Account({
-      name: 'account'
+      name: 'account',
     });
     await acc.insert();
 
@@ -173,49 +170,63 @@ describe('Generated Classes', () => {
     expect(sob['Name']).to.equal(acc2.name);
 
     await acc.delete();
-  })  
-  
-  it('handle ifModifiedSince', async () => {
-    const modifiedDate = new Date();
-    let acc = new Account({
-      name: 'account'
-    });
-    await acc.insert();
-    //@ts-expect-error
-    acc._client.request.interceptors.request.use((config) => {
-      if (config.method === 'patch')
-        expect(config.headers["If-Modified-Since"]).to.equal(modifiedDate.toUTCString());
-      return config
-    });
-    acc.name = "account2";
-    await acc.update({ refresh: false, ifModifiedSince: new Date()});
-    await acc.delete();
-  })
+  });
 
-  it('handle ifUmodifiedSince', async () => {
+  it('handle multiple headers', async () => {
     const modifiedDate = new Date();
     let acc = new Account({
-      name: 'account'
+      name: 'account',
     });
     await acc.insert();
     //@ts-expect-error
     acc._client.request.interceptors.request.use((config) => {
-      if (config.method === 'patch')
-        expect(config.headers["If-Unmodified-Since"]).to.equal(modifiedDate.toUTCString());
-      return config
+      if (config.method === 'patch') expect(config.headers['If-Modified-Since']).to.equal(modifiedDate.toUTCString());
+      return config;
     });
-    acc.name = "account2";
-    await acc.update({ refresh: false, ifUnmodifiedSince: new Date()});
+    acc.name = 'account2';
+    await acc.update({
+      refresh: false,
+      headers: [
+        {
+          'If-Unmodified-Since': new Date(),
+          'If-Modified-Since': new Date('2021-12-12'),
+          'Sforce-Auto-Assign': false,
+          'Sforce-Mru': { updateMru: true },
+        },
+      ],
+    });
     await acc.delete();
-  })
+  });
+
+  it('handle generic headers', async () => {
+    const modifiedDate = new Date();
+    let acc = new Account({
+      name: 'account',
+    });
+    await acc.insert();
+    //@ts-expect-error
+    acc._client.request.interceptors.request.use((config) => {
+      if (config.method === 'patch') expect(config.headers['If-Unmodified-Since']).to.equal(modifiedDate.toUTCString());
+      return config;
+    });
+    acc.name = 'account2';
+    await acc.update({
+      refresh: false,
+      headers: [
+        {
+          'Generic-Header': { header: 'Sforce-Mru', value: 'updateMru=true' },
+        },
+      ],
+    });
+    await acc.delete();
+  });
 
   it('multi-picklists', async () => {
-
     const { multiPick } = Account.PICKLIST;
 
     let acc = new Account({
       name: 'account',
-      multiPick: [multiPick.ONE, 'two']
+      multiPick: [multiPick.ONE, 'two'],
     });
     await acc.insert();
 
@@ -233,10 +244,9 @@ describe('Generated Classes', () => {
   });
 
   it('refresh', async () => {
-
     let acc = new Account({
       name: 'test account',
-      website: 'www.facepamplet.com'
+      website: 'www.facepamplet.com',
     });
     await acc.insert();
     let acc2 = (await Account.retrieve(`SELECT Id, Name FROM Account WHERE Id = '${acc.id}'`))[0];
@@ -253,14 +263,14 @@ describe('Generated Classes', () => {
     let acc = new Account({ name: 'testing' });
     await acc.insert();
 
-    let acc2 = (await Account.retrieve(fields => {
-      return {
-        select: fields.select('lastModifiedDate', 'createdById'),
-        where: [
-          { field: fields.select('id'), op: '=', val: acc.id }
-        ]
-      };
-    }))[0];
+    let acc2 = (
+      await Account.retrieve((fields) => {
+        return {
+          select: fields.select('lastModifiedDate', 'createdById'),
+          where: [{ field: fields.select('id'), op: '=', val: acc.id }],
+        };
+      })
+    )[0];
 
     expect(acc2.lastModifiedDate).not.null;
     expect(acc2.createdById).not.null;
@@ -268,59 +278,73 @@ describe('Generated Classes', () => {
 
   it('Collections End-to-End', async () => {
     let acc = new Account({
-      name: 'test account'
+      name: 'test account',
     });
     await acc.insert();
 
     let contacts = [];
     const contactSize = 50;
     for (let i = 0; i < contactSize; i++) {
-      contacts.push(new Contact({
-        accountId: acc.id,
-        firstName: `test`,
-        lastName: `contact ${i}`
-      }));
+      contacts.push(
+        new Contact({
+          accountId: acc.id,
+          firstName: `test`,
+          lastName: `contact ${i}`,
+        })
+      );
     }
 
     let bulk = new CompositeCollection();
     let insertResults = await bulk.insert(contacts);
     expect(contacts[0]._modified.size).to.equal(0);
 
-    insertResults.forEach(r => {
+    insertResults.forEach((r) => {
       if (!r.success) {
-        throw r.errors.map(e => e.message).join(', ');
+        throw r.errors.map((e) => e.message).join(', ');
       }
     });
 
-    acc = (await Account.retrieve(`SELECT Id, (SELECT ${Contact.FIELDS.name.apiName} FROM ${Account.FIELDS.contacts.apiName}) FROM Account WHERE Id = '${acc.id}'`))[0];
+    acc = (
+      await Account.retrieve(
+        `SELECT Id, (SELECT ${Contact.FIELDS.name.apiName} FROM ${Account.FIELDS.contacts.apiName}) FROM Account WHERE Id = '${acc.id}'`
+      )
+    )[0];
 
     expect(acc.contacts.length).to.equal(contactSize);
 
-    contacts.forEach(c => {
+    contacts.forEach((c) => {
       c.email = 'test@example.com';
     });
 
     let updateResults = await bulk.update(contacts);
     expect(contacts[0]._modified.size).to.equal(0);
-    updateResults.forEach(r => {
+    updateResults.forEach((r) => {
       if (!r.success) {
-        throw r.errors.map(e => e.message).join(', ');
+        throw r.errors.map((e) => e.message).join(', ');
       }
     });
 
-    acc = (await Account.retrieve(`SELECT Id, (SELECT ${Contact.FIELDS.name.apiName}, ${Contact.FIELDS.email} FROM ${Account.FIELDS.contacts.apiName}) FROM Account WHERE Id = '${acc.id}'`))[0];
-    acc.contacts.forEach(c => {
+    acc = (
+      await Account.retrieve(
+        `SELECT Id, (SELECT ${Contact.FIELDS.name.apiName}, ${Contact.FIELDS.email} FROM ${Account.FIELDS.contacts.apiName}) FROM Account WHERE Id = '${acc.id}'`
+      )
+    )[0];
+    acc.contacts.forEach((c) => {
       expect(c.email).to.equal('test@example.com');
     });
 
     let delResults = await bulk.delete(contacts);
-    delResults.forEach(r => {
+    delResults.forEach((r) => {
       if (!r.success) {
-        throw r.errors.map(e => e.message).join(', ');
+        throw r.errors.map((e) => e.message).join(', ');
       }
     });
 
-    acc = (await Account.retrieve(`SELECT Id, (SELECT ${Contact.FIELDS.name.apiName} FROM ${Account.FIELDS.contacts.apiName}) FROM Account WHERE Id = '${acc.id}'`))[0];
+    acc = (
+      await Account.retrieve(
+        `SELECT Id, (SELECT ${Contact.FIELDS.name.apiName} FROM ${Account.FIELDS.contacts.apiName}) FROM Account WHERE Id = '${acc.id}'`
+      )
+    )[0];
 
     expect(acc.contacts.length).to.equal(0);
 
@@ -330,14 +354,10 @@ describe('Generated Classes', () => {
   it('should set relation by external id', async () => {
     const extId = '123abcd';
     // setup account
-    let accs = await Account.retrieve(f => {
+    let accs = await Account.retrieve((f) => {
       return {
-        select: [
-          ...f.select('id', 'testExternalId')
-        ],
-        where: [
-          { field: f.select('testExternalId'), op: '=', val: extId }
-        ]
+        select: [...f.select('id', 'testExternalId')],
+        where: [{ field: f.select('testExternalId'), op: '=', val: extId }],
       };
     });
 
@@ -347,7 +367,7 @@ describe('Generated Classes', () => {
     } else {
       acc = new Account({
         name: 'test external id account',
-        testExternalId: extId
+        testExternalId: extId,
       });
       await acc.insert();
     }
@@ -355,83 +375,74 @@ describe('Generated Classes', () => {
     let contact = new Contact({
       firstName: 'john',
       lastName: 'doe',
-      account: new Account({ testExternalId: extId })
+      account: new Account({ testExternalId: extId }),
     });
 
     await contact.insert();
 
-    let retCont = await Contact.retrieve(f => {
+    let retCont = await Contact.retrieve((f) => {
       return {
-        select: [
-          f.select('accountId')
-        ],
-        where: [
-          { field: f.select('id'), op: '=', val: contact.id }
-        ]
+        select: [f.select('accountId')],
+        where: [{ field: f.select('id'), op: '=', val: contact.id }],
       };
     });
 
     expect(retCont[0].accountId).to.equal(acc.id);
-
   });
 
   it('prepareFor Apex', async () => {
-
     let c = new Contact({
       id: '123',
       accountId: 'abc',
       firstName: `john`,
       lastName: `doe`,
       account: new Account({
-        name: 'acme'
-      })
+        name: 'acme',
+      }),
     });
 
-    expect(c.toJson({ dmlMode: 'all', sendChildObj: true, sendParentObj: true, hideAttributes: true })).to.deep.equal(
-      {
-        Id: '123',
-        AccountId: 'abc',
-        FirstName: 'john',
-        LastName: 'doe',
-        Account: {
-          Name: 'acme'
-        }
-      }
-    );
+    expect(c.toJson({ dmlMode: 'all', sendChildObj: true, sendParentObj: true, hideAttributes: true })).to.deep.equal({
+      Id: '123',
+      AccountId: 'abc',
+      FirstName: 'john',
+      LastName: 'doe',
+      Account: {
+        Name: 'acme',
+      },
+    });
 
     let acc = new Account({
       id: '123',
-      contacts: [new Contact({
-        firstName: 'john',
-        lastName: 'doe'
-      })]
+      contacts: [
+        new Contact({
+          firstName: 'john',
+          lastName: 'doe',
+        }),
+      ],
     });
 
-    expect(acc.toJson({ dmlMode: 'all', sendChildObj: true, sendParentObj: true, hideAttributes: true })).to.deep.equal(
-      {
-        Id: '123',
-        Contacts: { records: [{ FirstName: 'john', LastName: 'doe' }] }
-      }
-    );
+    expect(acc.toJson({ dmlMode: 'all', sendChildObj: true, sendParentObj: true, hideAttributes: true })).to.deep.equal({
+      Id: '123',
+      Contacts: { records: [{ FirstName: 'john', LastName: 'doe' }] },
+    });
   });
 
   it('prepareFor Apex End To End', async () => {
     let acc = new Account({
       id: '123',
-      contacts: [new Contact({
-        firstName: 'john',
-        lastName: 'doe'
-      })],
+      contacts: [
+        new Contact({
+          firstName: 'john',
+          lastName: 'doe',
+        }),
+      ],
       owner: new User({
-        'email': 'example@gmai.com'
-      })
+        email: 'example@gmai.com',
+      }),
     });
 
     const sfSob = acc.toJson({ dmlMode: 'all', sendChildObj: true, sendParentObj: true, hideAttributes: true });
-    let data = (await new Rest().request.post<SObject>(
-      '/services/apexrest/myservice',
-      { acc: sfSob }
-    )).data;
+    let data = (await new Rest().request.post<SObject>('/services/apexrest/myservice', { acc: sfSob })).data;
     const retAcc = Account.fromSFObject(data);
     expect(acc.id).to.deep.equal(retAcc.id);
     expect(acc.contacts[0].firstName).to.deep.equal(retAcc.contacts[0].firstName);
@@ -441,8 +452,8 @@ describe('Generated Classes', () => {
 
   it('composite retrieve', async () => {
     let results = await compositeRetrieve(Contact, Account, User)(
-      f => ({ select: f.select('cleanStatus', 'email', 'accountId') }),
-      f => ({ select: f.select('numberOfEmployees', 'accountNumber', 'active') }),
+      (f) => ({ select: f.select('cleanStatus', 'email', 'accountId') }),
+      (f) => ({ select: f.select('numberOfEmployees', 'accountNumber', 'active') }),
       'select x from blah'
     );
     let contactResults = results[0];
@@ -474,19 +485,20 @@ describe('Generated Classes', () => {
     let c = new Contact({
       firstName: 'test',
       lastName: 'contact',
-      birthdate: getCalendarDate()
+      birthdate: getCalendarDate(),
     });
     await c.insert();
     expect(c.id).to.not.be.null;
 
-    let c2 = (await Contact.retrieve(f => ({
-      select: [f.select('birthdate')],
-      where: [{ field: 'id', val: c.id }]
-    })))[0];
+    let c2 = (
+      await Contact.retrieve((f) => ({
+        select: [f.select('birthdate')],
+        where: [{ field: 'id', val: c.id }],
+      }))
+    )[0];
 
     expect(c2.birthdate).to.deep.equal(c.birthdate);
 
     await c.delete();
   });
-
 });


### PR DESCRIPTION
1. Some headers have default values, for example, the assignment rule header is default to true, which we want to update https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/headers_autoassign.htm 
2. We also need some headers to make Salesforce Conditional updates https://github.com/vacasaoss/ts-force/pull/5, at the meantime, handle the errors that is likely to be returned when the object doesn't match the conditions. https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_rest_conditional_requests.htm

Currently, ts-force doesn't support adding headers. Based on this, we add some headers to send in patch requests. The below are the headers we intend to add.
```
Sforce-Auto-Assign: FALSE
If-Match: "Jbjuzw7dbhaEG3fd90kJbx6A0ow=-gzip", "U5iWijwWbQD18jeiXwsqxeGpZQk=-gzip"
If-None-Match: "Jbjuzw7dbhaEG3fd90kJbx6A0ow=-gzip", "U5iWijwWbQD18jeiXwsqxeGpZQk=-gzip"
If-Modified-Since: Tue, 10 Aug 2015 00:00:00 GMT
If-Unmodified-Since: Tue, 10 Aug 2015 00:00:00 GMT
Sforce-Mru: updateMru=true
x-sfdc-packageversion-clientPackage: 1.0 //x-sfdc-packageversion-[namespace]: xx.x , where [namespace] is the unique namespace of the managed package and xx.x is the package version.
```
